### PR TITLE
Add abstraction to make it easier to access programmatically

### DIFF
--- a/src/main/java/no/s11/owlapi/ProfileChecker.java
+++ b/src/main/java/no/s11/owlapi/ProfileChecker.java
@@ -21,15 +21,13 @@ import org.semanticweb.owlapi.profiles.OWLProfileViolation;
 
 public class ProfileChecker {
 
-	private static OWLProfile DEFAULT_PROFILE = new OWL2Profile();
-	private static List<OWLProfile> PROFILES = Arrays.asList(new OWL2DLProfile(),
+	public static final OWLProfile DEFAULT_PROFILE = new OWL2Profile();
+	public static final OWLProfile[] PROFILES = new OWLProfile[] {new OWL2DLProfile(),
 			new OWL2ELProfile(), new OWL2Profile(), new OWL2QLProfile(),
-			new OWL2RLProfile());
-
-	private OWLOntologyManager m = OWLManager.createOWLOntologyManager();
+			new OWL2RLProfile()};
 
 	public static void main(String[] args) throws OWLOntologyCreationException {
-        if (args.length == 0 || args[0].equals("-h")) {
+        if (args.length == 0 || args[0].equals("-h") || args[0].equals("--help")) {
             System.out
                     .println("Usage: profilechecker.jar <ontology.owl> [profile]");
             System.out.println();
@@ -44,68 +42,79 @@ public class ProfileChecker {
                 System.out.println();
             }
             System.out.println("--all");
-            System.exit(1);
+            System.exit(-1);
         }
 	    
-		System.exit(new ProfileChecker().check(args));
+		System.exit(ProfileChecker.parseAndCheck(args));
 	}
 
-	public int check(String[] args) throws OWLOntologyCreationException {
+	private static int parseAndCheck(String[] args) throws OWLOntologyCreationException {
 
+	    if(args.length == 0 || "--all".equals(args[0])) {
+	        throw new IllegalArgumentException("Did not specify an ontology to check.");
+	    }
+	    
 		IRI documentIRI = IRI.create(args[0]);
 		if (!documentIRI.isAbsolute()) {
 			// Assume it's a file
 			documentIRI = IRI.create(new File(args[0]));
 		}
+	    OWLOntologyManager m = OWLManager.createOWLOntologyManager();
+
 		OWLOntology o = m.loadOntologyFromOntologyDocument(documentIRI);
-		OWLProfile profile = null;
 
 		if (args.length > 1) {
 			String profileName = args[1];
-			for (OWLProfile p : PROFILES) {
-				if (p.getClass().getSimpleName().equals(profileName)) {
-					profile = p;
-				}
-			}
-			if (profile == null && !profileName.equals("--all")) {
+            if (profileName.equals("--all")) {
+                return ProfileChecker.check(o, System.out, System.err, PROFILES);
+            } else {
+            
+    			for (OWLProfile p : PROFILES) {
+    				if (p.getClass().getSimpleName().equals(profileName)) {
+    	                return ProfileChecker.check(o, System.out, System.err, p);
+    				}
+    			}
 				throw new IllegalArgumentException("Unknown profile: "
 						+ profileName);
-			}
+            }
 		} else {
-			profile = DEFAULT_PROFILE;
+	        return ProfileChecker.check(o, System.out, System.err, DEFAULT_PROFILE);
 		}
-		
-		return check(o, System.out, System.err, profile);
 	}
 	
-	public int check(OWLOntology o, PrintStream out, PrintStream err, OWLProfile ... profiles) {
-		if (profiles == null || profiles.length == 0) {
-			boolean anyFailed = false;
-			for (OWLProfile p : PROFILES) {
-				out.print(p.getClass().getSimpleName() + ": ");
-				OWLProfileReport report = p.checkOntology(o);
-				if (report.isInProfile()) {
-					out.println("OK");
-				} else {
-					err.println(report.getViolations().size()
-							+ " violations");
-					anyFailed = true;
-				}
+	/**
+	 * Checks the given ontology to determine whether it fits all of the given profiles.
+	 * 
+	 * @param o The ontology to check
+	 * @param out The standard output stream for printing informational messages
+	 * @param err The error output stream for printing error messages
+	 * @param profiles The profiles to check the ontology against.
+	 * @return 0 if the ontology is in all of the given profiles, and otherwise return the number of profiles that failed.
+	 * @throws IllegalArgumentException if no profiles were specified or the ontology was null
+	 */
+	public static int check(OWLOntology o, PrintStream out, PrintStream err, OWLProfile ... profiles) {
+	    
+	    if(profiles == null || profiles.length == 0) {
+	        throw new IllegalArgumentException("No profiles specified to check");
+	    }
+	    
+	    if(o == null) {
+            throw new IllegalArgumentException("No ontology specified to check");
+	    }
+	    
+        int anyFailed = 0;
+        for (OWLProfile profile : profiles) {
+			OWLProfileReport report = profile.checkOntology(o);
+			for (OWLProfileViolation v : report.getViolations()) {
+				err.println(v.toString());
 			}
-			return anyFailed ? 1 : 0;
-		} else {
-            for (OWLProfile profile : profiles) {
-    			OWLProfileReport report = profile.checkOntology(o);
-    			for (OWLProfileViolation v : report.getViolations()) {
-    				err.println(v.toString());
-    			}
-    			if (!report.isInProfile()) {
-    				return 1;
-    			}
-            }
-			return 0;
-		}
-
+			
+			if (!report.isInProfile()) {
+                anyFailed++;
+			}
+        }
+        
+        return anyFailed;
 	}
 
 }


### PR DESCRIPTION
Split up the args verification, and the actual checking code into separate places to make it easier to use both of the check methods programmatically.
